### PR TITLE
internal/conn: destroy connection on timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 
 script:
-  - /home/travis/gopath/src/github.com/iwanbk/rimcu/redis-unstable/src/redis-server&
+  - /home/travis/gopath/src/github.com/iwanbk/rimcu/redis/src/redis-server&
   - go build ./...
   - make lint
   - gotest -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/internal/resp3pool/conn_test.go
+++ b/internal/resp3pool/conn_test.go
@@ -63,7 +63,7 @@ func TestConn(t *testing.T) {
 }
 
 func (c *Conn) setex(key, val string, exp int) error {
-	_, err := c.do("SET", key, val, "EX", strconv.Itoa(exp))
+	_, err := c.do(context.Background(), "SET", key, val, "EX", strconv.Itoa(exp))
 	return err
 }
 
@@ -72,7 +72,7 @@ func (c *Conn) setex(key, val string, exp int) error {
 // It returns ErrNotFound if there is no cache with the given key
 func (c *Conn) get(key string) (string, error) {
 	// execute redis commands
-	resp, err := c.Do("GET", key)
+	resp, err := c.Do(context.Background(), "GET", key)
 	if err != nil {
 		return "", err
 	}

--- a/internal/resp3pool/pool.go
+++ b/internal/resp3pool/pool.go
@@ -118,7 +118,12 @@ func (p *Pool) putConnBack(conn *Conn) {
 	p.mtx.Lock()
 	p.conns = append(p.conns, conn)
 	p.mtx.Unlock()
+	p.releaseConn()
+}
+
+func (p *Pool) releaseConn() {
 	<-p.maxConnsCh
+
 }
 
 func (p *Pool) Close() {

--- a/scripts/install_redis_6.sh
+++ b/scripts/install_redis_6.sh
@@ -1,4 +1,5 @@
-wget -c https://github.com/antirez/redis/archive/unstable.tar.gz
-tar zxf unstable.tar.gz
-cd redis-unstable
+wget -c https://github.com/antirez/redis/archive/6.0-rc1.tar.gz
+tar zxf 6.0-rc1.tar.gz
+mv redis-6.0-rc1 redis
+cd redis
 make

--- a/strings.go
+++ b/strings.go
@@ -206,7 +206,7 @@ func (sc *StringsCache) _do(ctx context.Context, cmd string, args ...string) (*r
 		return nil, err
 	}
 
-	resp, err := conn.Do(cmd, args...)
+	resp, err := conn.Do(ctx, cmd, args...)
 
 	conn.Close()
 


### PR DESCRIPTION
Close and destroy the connection on response timeout, the connection will not go back to the pool.
    
It is simpler & easier to do this because we don't know whether the response
will eventually come, that need to be handled by the next command caller.