### PR TITLE
resp2: rework the API.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '3.2'
 services:
   redis:
-    image: redis:6.0-rc3-alpine
+    image: redis:6.0-rc4-alpine
     ports:
       - 6379:6379

--- a/resp2/string_result.go
+++ b/resp2/string_result.go
@@ -1,0 +1,31 @@
+package resp2
+
+import (
+	"github.com/iwanbk/rimcu/internal/redigo/redis"
+)
+
+// StringResult represents result of the strings cache read operation
+type StringResult struct {
+	val interface{}
+	err error
+}
+
+func newStringResult(val interface{}, err error) *StringResult {
+	return &StringResult{
+		val: val,
+		err: err,
+	}
+}
+
+// Err returns error of the command result, if any
+func (sr *StringResult) Err() error {
+	return sr.err
+}
+
+// String returns string representation of the result
+func (sr *StringResult) String() (string, error) {
+	if sr.err != nil {
+		return "", sr.err
+	}
+	return redis.String(sr.val, nil)
+}

--- a/resp2/strings_test.go
+++ b/resp2/strings_test.go
@@ -2,7 +2,6 @@ package resp2
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -82,8 +81,8 @@ func TestStringsCache_Set_Invalidate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get to activate listening
-		_, err = sc2.Get(ctx, key1, testExpSecond)
-		require.NoError(t, err)
+		res := sc2.Get(ctx, key1, testExpSecond)
+		require.NoError(t, res.Err())
 
 	}
 
@@ -131,7 +130,7 @@ func TestStringsCache_Get_Valid_InitInMem(t *testing.T) {
 		require.NoError(t, err)
 
 		// make sure the value is as expected
-		val, err := sc1.Get(ctx, key1, testExpSecond)
+		val, err := sc1.Get(ctx, key1, testExpSecond).String()
 		require.NoError(t, err)
 		require.Equal(t, val1, val)
 	}
@@ -148,11 +147,11 @@ func TestStringsCache_Get_Valid_InitInMem(t *testing.T) {
 	// do the action : Get
 	{
 		// get
-		val, err := sc2.Get(ctx, key1, testExpSecond)
+		val, err := sc2.Get(ctx, key1, testExpSecond).String()
 		require.NoError(t, err)
 		require.Equal(t, val1, val)
 
-		val, err = sc3.Get(ctx, key1, testExpSecond)
+		val, err = sc3.Get(ctx, key1, testExpSecond).String()
 		require.NoError(t, err)
 		require.Equal(t, val1, val)
 	}
@@ -193,7 +192,7 @@ func TestStringsCache_Get_Invalid_NotInitInMem(t *testing.T) {
 	// do the action : get key that not exists
 	{
 		// get
-		_, err := sc1.Get(ctx, key1, testExpSecond)
+		_, err := sc1.Get(ctx, key1, testExpSecond).String()
 		require.Error(t, err)
 	}
 
@@ -228,10 +227,10 @@ func TestStringsCache_Del_ValidKey_Propagate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get to activate listening
-		_, err = sc2.Get(ctx, key1, testExpSecond)
+		_, err = sc2.Get(ctx, key1, testExpSecond).String()
 		require.NoError(t, err)
 
-		_, err = sc3.Get(ctx, key1, testExpSecond)
+		_, err = sc3.Get(ctx, key1, testExpSecond).String()
 		require.NoError(t, err)
 	}
 
@@ -283,7 +282,6 @@ func createStringsCacheClient(t *testing.T, numCli int) ([]*StringsCache, func()
 			ServerAddr: serverAddr,
 			CacheSize:  10000,
 			Logger:     &debugLogger{},
-			ClientID:   []byte(fmt.Sprintf("client_%d", i+1)),
 		})
 		require.NoError(t, err)
 		caches = append(caches, cli)

--- a/scripts/install_redis_6.sh
+++ b/scripts/install_redis_6.sh
@@ -1,5 +1,5 @@
-wget -c https://github.com/antirez/redis/archive/6.0-rc3.tar.gz
-tar zxf 6.0-rc3.tar.gz
-mv redis-6.0-rc3 redis
+wget -c https://github.com/antirez/redis/archive/6.0-rc4.tar.gz
+tar zxf 6.0-rc4.tar.gz
+mv redis-6.0-rc4 redis
 cd redis
 make


### PR DESCRIPTION
Warp return type of the read operation with struct.
Make it easier to convert to any type.

For write operation, accept interface instead of string